### PR TITLE
Compare table changed the comparison logic

### DIFF
--- a/src/utils/compareTable.js
+++ b/src/utils/compareTable.js
@@ -1,13 +1,3 @@
-/*
-Comparing the two table in right order
-earlier -
-    example -> (p->q) and (~q->p) are equivalent but the function return false
-    since it end up comparing -> 
-    table in wrong order - p|q|expression and q|p|expression which return false
-    
-    I have updated the code so that the comparission happens in correct sequence
-
-*/
 export const compareTables = (table1, expression1, table2, expression2) => {
   if (!Array.isArray(table1) || !Array.isArray(table2)) return false;
 

--- a/src/utils/compareTable.js
+++ b/src/utils/compareTable.js
@@ -1,16 +1,49 @@
-export const compareTables = (table1 , expression1 , table2, expression2) => {
-    if (table1.length !== table2.length) return false;
+/*
+Comparing the two table in right order
+earlier -
+    example -> (p->q) and (~q->p) are equivalent but the function return false
+    since it end up comparing -> 
+    table in wrong order - p|q|expression and q|p|expression which return false
+    
+    I have updated the code so that the comparission happens in correct sequence
 
-    console.log("Table 1: ", table1);
-    console.log("Expresión 1:", expression1)
-    console.log("Table 2: ", table2);
-    console.log("Expresión 2:" , expression2)
-    for (let i = 0; i < table1.length; i++) {
-        if (table1[i][expression1] !== table2[i][expression2]) {
-            return false;
-        }
+*/
+export const compareTables = (table1, expression1, table2, expression2) => {
+  if (!Array.isArray(table1) || !Array.isArray(table2)) return false;
+
+  // Determine variable column names for each table 
+  const vars1 = Object.keys(table1[0] || {})
+  const vars2 = Object.keys(table2[0] || {})
+  console.log("vars1 and varse2",vars1,vars2)
+
+  // Intersection of variables 
+  const vars = vars2.filter(v => vars1.includes(v));
+  console.log("vars: ",vars);
+  // For each row in table1, find a row in table2 with identical variable assignments,
+  // then compare the expression results.
+  for (const row1 of table1) {
+    const match = table2.find(row2 => {
+      return vars.every(v =>
+        Object.prototype.hasOwnProperty.call(row1, v) &&
+        Object.prototype.hasOwnProperty.call(row2, v) &&
+        Boolean(row1[v]) === Boolean(row2[v])
+      );
+    });
+
+    // No matching assignment found -> tables differ
+    if (!match) {
+      console.log("No matching assignment found for row:", row1);
+      return false;
     }
 
+    // Compare expression results (boolean-normalize both sides)
+    if (Boolean(row1[expression1]) !== Boolean(match[expression2])) {
+      console.log("Mismatch for assignment:", vars.reduce((acc, v) => (acc[v]=row1[v], acc), {}));
+      console.log("table1 value:", row1[expression1], "table2 value:", match[expression2]);
+      return false;
+    }
+  }
 
-    return true;
+  // All rows matched
+  return true;
 };


### PR DESCRIPTION

**Comparing the two table in right order**
earlier -
    example -> (p->q) and ((~q)->(~p)) are equivalent but the function returns false since it ends up comparing 
    table in wrong order.
    example - p |q | expression and q | p | expression which return false
    I have updated the code so that the comparison happens in correct sequence 

attached Image-
<img width="1575" height="779" alt="Screenshot 2025-10-31 113541" src="https://github.com/user-attachments/assets/9e0cdf50-d70a-49f8-927f-cce35ee7c822" />



